### PR TITLE
fix bug where dbg value intrinsics were emitted prior to the last phi

### DIFF
--- a/src/LLDebugInfo/LLDebugInfo.h
+++ b/src/LLDebugInfo/LLDebugInfo.h
@@ -24,6 +24,7 @@ namespace llvm {
     DIBuilder DIB;
     DICompileUnit *CU;
     DIFile *File;
+    std::vector<llvm::Instruction *> DbgValues;
 
   public:
     LLDebugInfo(llvm::Module *M, StringRef File, StringRef Directory);


### PR DESCRIPTION
node

This was causing the code I wrote in my last PR to generate a module that wouldn't verify when applied to basic blocks with more than one phi node in them. This PR should fix that issue.